### PR TITLE
Update provider.tf to remove development references

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     prismacloud-waas = {
-      source  = "terraform.local/PaloAltoNetworks/prismacloud-waas"
-      version = "0.0.1"
+      source  = "PaloAltoNetworks/prismacloud-waas"
+      version = "1.0.1"
     }
   }
 }


### PR DESCRIPTION
To remove legacy configuration, referenced local provider content and a out of data version (0.0.1 has been replaced to be 1.0.1 as per advertised versioning).

## Description

Updated provider example, to remove (what I presume is) legacy references to initial development. So that anyone using this will be able to pull from terraform provider registry.  

## Motivation and Context
Reduces confusion and sets values to currently known versioning. 

## How Has This Been Tested?

terraform init passes. 

## Types of changes

Documentation improvement. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
