### PR TITLE
the PC API is degenerate in that it does not accept trailing slashes;…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ description: |-
 terraform {
   required_providers {
     prismacloud-waas = {
-      source  = "terraform.local/PaloAltoNetworks/prismacloud-waas"
-      version = "0.0.1"
+      source  = "PaloAltoNetworks/prismacloud-waas"
+      version = "1.0.1"
     }
   }
 }

--- a/internal/api/collection.go
+++ b/internal/api/collection.go
@@ -12,7 +12,11 @@ import (
 )
 
 func (c *Client) collectionsEndpoint() *requests.Builder {
-	return c.apiBuilder.Clone().Pathf("api/%s/collections", c.apiVersion)
+	return c.apiBuilder.Clone().Path("collections")
+}
+
+func (c *Client) collectionEndpoint() *requests.Builder {
+	return c.apiBuilder.Clone().Path("collections/")
 }
 
 type Collection struct {
@@ -464,8 +468,7 @@ func (c *Client) UpdateCollection(ctx context.Context, req UpdateCollectionReque
 			}
 		}
 	}
-	// because the API endpoints are degenerate and don't support a trailing slash, we have to re-supply the `collections` path element
-	err := c.collectionsEndpoint().Pathf("./collections/%s", req.Name).BodyJSON(req).Put().Fetch(ctx)
+	err := c.collectionEndpoint().Path(req.Name).BodyJSON(req).Put().Fetch(ctx)
 	if err != nil {
 		return Collection{}, fmt.Errorf("update collection: %w", err)
 	}
@@ -483,7 +486,7 @@ func (c *Client) DeleteCollection(ctx context.Context, req DeleteCollectionReque
 		return DeleteCollectionResponse{}, fmt.Errorf("%w: name", MissingRequiredValue)
 	}
 	// because the API endpoints are degenerate and don't support a trailing slash, we have to re-supply the `collections` path element
-	err := c.collectionsEndpoint().Pathf("./collections/%s", req.Name).Delete().Fetch(ctx)
+	err := c.collectionEndpoint().Path(req.Name).Delete().Fetch(ctx)
 	if err != nil {
 		return DeleteCollectionResponse{}, fmt.Errorf("delete collection: %w", err)
 	}

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -249,11 +249,9 @@ func (p *Policy) findApplicationSpecLocation(id string) (ApplicationSpecLocation
 	return ApplicationSpecLocation{}, NotFound
 }
 
-const firewallPolicyPathFormat = "api/%s/policies/firewall/app/%s"
-
 func (c *Client) getPolicyEndpointBuilder(policyType PolicyType) (*requests.Builder, error) {
 	policyBuilder := func(policyPath string) *requests.Builder {
-		return c.apiBuilder.Clone().Pathf(firewallPolicyPathFormat, c.apiVersion, policyPath)
+		return c.apiBuilder.Clone().Path("policies/firewall/app/").Path(policyPath)
 	}
 	switch policyType {
 	case appEmbedded:
@@ -263,7 +261,7 @@ func (c *Client) getPolicyEndpointBuilder(policyType PolicyType) (*requests.Buil
 	case host:
 		return policyBuilder("host"), nil
 	default:
-		return nil, fmt.Errorf("unhandled policyType (%s)", policyType)
+		return nil, fmt.Errorf("unhandled policyType(%q)", policyType)
 	}
 }
 


### PR DESCRIPTION
… this can cause problems for the `request` library that assumes that trailing slashes on paths indicate a collection of resources and expects them to be present. This change absorbs/suppresses trailing slashes for less surprising behavior.

## Description

Accepts a Console URL with or without the trailing slash and simplifies handling of the PC API expectation of no trailing slashes.

## Motivation and Context

Fixes #4

## How Has This Been Tested?

Unit test


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

